### PR TITLE
fix: resolve 26 pre-existing TypeScript errors

### DIFF
--- a/src/components/ai/AIChat.tsx
+++ b/src/components/ai/AIChat.tsx
@@ -672,9 +672,9 @@ export function AIChat() {
                   }`}
                 >
                   {message.type === "ai" ? (
-                    <ReactMarkdown className="whitespace-pre-wrap text-sm leading-relaxed">
-                      {message.content}
-                    </ReactMarkdown>
+                    <div className="whitespace-pre-wrap text-sm leading-relaxed">
+                      <ReactMarkdown>{message.content}</ReactMarkdown>
+                    </div>
                   ) : (
                     <p className="whitespace-pre-wrap text-sm leading-relaxed">
                       {message.content}

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle, ChefHat } from "lucide-react";
 import React, { useState } from "react";
-import { useForm } from "react-hook-form";
+import { type Resolver, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { z } from "zod";
 import { useAuth } from "../../contexts/AuthContext";
@@ -40,8 +40,14 @@ function AuthFormRaw({ initialMode }: AuthFormProps) {
   const { signIn, signUp, isSupabaseConnected } = useAuth();
   const navigate = useNavigate();
 
+  // The form covers both sign-in and sign-up; sign-in uses a subset of the
+  // fields, so the resolver is typed to the wider SignUpFormData shape.
+  const resolver = zodResolver(
+    isSignUp ? signUpSchema : signInSchema
+  ) as unknown as Resolver<SignUpFormData>;
+
   const { register, handleSubmit, reset } = useForm<SignUpFormData>({
-    resolver: zodResolver(isSignUp ? signUpSchema : signInSchema),
+    resolver,
   });
 
   const onSubmit = async (data: SignUpFormData) => {

--- a/src/components/categories/SmartCategorySelector.test.tsx
+++ b/src/components/categories/SmartCategorySelector.test.tsx
@@ -33,7 +33,7 @@ describe("SmartCategorySelector", () => {
 
   it("calls analyzeCategory when Smart Suggest is clicked and shows suggestion banner", async () => {
     // Mock fetch to return a suggestion
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         category: "Fruits",
@@ -59,7 +59,7 @@ describe("SmartCategorySelector", () => {
 
   it("applies and dismisses a suggestion", async () => {
     const onCategoryChange = vi.fn();
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         category: "Fruits",

--- a/src/components/leftovers/LeftoverForm.test.tsx
+++ b/src/components/leftovers/LeftoverForm.test.tsx
@@ -1,14 +1,26 @@
+import type { User } from "@supabase/supabase-js";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 import * as AuthContext from "../../contexts/AuthContext";
 import { AuthProvider } from "../../contexts/AuthContext";
 import { LeftoverForm } from "./LeftoverForm";
 
-// Mock useAuth to always return a user
-vi.spyOn(AuthContext, "useAuth").mockReturnValue({ user: { id: "test-user" } });
+const mockUser: User = {
+  id: "test-user",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2024-01-01",
+};
 
-function Wrapper({ children }) {
+// Mock useAuth to always return a user
+vi.spyOn(AuthContext, "useAuth").mockReturnValue({
+  user: mockUser,
+} as ReturnType<typeof AuthContext.useAuth>);
+
+function Wrapper({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider isSupabaseConnectedOverride={true}>{children}</AuthProvider>
   );
@@ -16,7 +28,9 @@ function Wrapper({ children }) {
 
 describe("LeftoverForm", () => {
   it("renders all input fields", () => {
-    render(<LeftoverForm onSubmit={vi.fn()} />, { wrapper: Wrapper });
+    render(<LeftoverForm onCancel={vi.fn()} onSubmit={vi.fn()} />, {
+      wrapper: Wrapper,
+    });
     expect(screen.getByLabelText("Leftover Name")).toBeInTheDocument();
     expect(screen.getByLabelText("Quantity")).toBeInTheDocument();
     expect(screen.getByLabelText("Unit")).toBeInTheDocument();
@@ -24,7 +38,9 @@ describe("LeftoverForm", () => {
 
   it("calls onSubmit with form data", () => {
     const onSubmit = vi.fn();
-    render(<LeftoverForm onSubmit={onSubmit} />, { wrapper: Wrapper });
+    render(<LeftoverForm onCancel={vi.fn()} onSubmit={onSubmit} />, {
+      wrapper: Wrapper,
+    });
     fireEvent.change(screen.getByLabelText("Leftover Name"), {
       target: { value: "Soup" },
     });

--- a/src/components/recipes/RecipeCard.test.tsx
+++ b/src/components/recipes/RecipeCard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Recipe } from "../../types";
 import { RecipeCard } from "./RecipeCard";
 
 const baseRecipe = {
@@ -16,7 +17,7 @@ const baseRecipe = {
   cuisine_type: "Italian",
   created_at: "2024-01-01",
   updated_at: "2024-01-01",
-};
+} satisfies Recipe;
 
 describe("RecipeCard", () => {
   beforeEach(() => {

--- a/src/components/recipes/RecipeDetailModal.test.tsx
+++ b/src/components/recipes/RecipeDetailModal.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, it, vi } from "vitest";
+import type { Recipe } from "../../types";
 import { RecipeDetailModal } from "./RecipeDetailModal";
 
 const recipe = {
@@ -15,7 +16,7 @@ const recipe = {
   difficulty: "Easy",
   created_at: "2024-01-01",
   updated_at: "2024-01-01",
-};
+} satisfies Recipe;
 
 const baseProps = {
   open: true,

--- a/src/components/recipes/RecipeList.tsx
+++ b/src/components/recipes/RecipeList.tsx
@@ -40,7 +40,7 @@ function getRecipeMatchInfo(
   return;
 }
 
-const RecipeGridCell: React.FC<CellComponentProps<RecipeGridCellData>> = ({
+const RecipeGridCell = ({
   ariaAttributes,
   columnIndex,
   rowIndex,
@@ -53,7 +53,7 @@ const RecipeGridCell: React.FC<CellComponentProps<RecipeGridCellData>> = ({
   onEdit,
   onDelete,
   columnCount,
-}) => {
+}: CellComponentProps<RecipeGridCellData>) => {
   const index = rowIndex * columnCount + columnIndex;
 
   if (index >= recipes.length) {

--- a/src/components/shopping/ShoppingListItems.test.tsx
+++ b/src/components/shopping/ShoppingListItems.test.tsx
@@ -1,39 +1,73 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, expect, it, vi } from "vitest";
+import type { ShoppingListItem } from "../../types";
 import { ShoppingListItems } from "./ShoppingListItems";
 
 const items = [
-  { id: "1", name: "Eggs", quantity: 1, unit: "dozen", is_purchased: false },
-  { id: "2", name: "Milk", quantity: 2, unit: "liters", is_purchased: true },
-];
+  {
+    id: "1",
+    name: "Eggs",
+    quantity: 1,
+    unit: "dozen",
+    is_purchased: false,
+    category: "Dairy",
+    shopping_list_id: "list-1",
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+  },
+  {
+    id: "2",
+    name: "Milk",
+    quantity: 2,
+    unit: "liters",
+    is_purchased: true,
+    category: "Dairy",
+    shopping_list_id: "list-1",
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+  },
+] satisfies ShoppingListItem[];
 
 describe("ShoppingListItems", () => {
   it("renders all items", () => {
-    render(<ShoppingListItems items={items} onToggle={vi.fn()} />);
-    expect(screen.getByText("Eggs")).toBeInTheDocument();
-    expect(screen.getByText("Milk")).toBeInTheDocument();
-  });
-
-  it("shows purchased state", () => {
-    render(<ShoppingListItems items={items} onToggle={vi.fn()} />);
-    expect(screen.getByText("Milk")).toHaveClass("line-through");
-  });
-
-  it("calls onToggle when item is clicked", () => {
-    const onToggle = vi.fn();
     render(
       <ShoppingListItems
         items={items}
         onDelete={vi.fn()}
         onEdit={vi.fn()}
-        onToggle={onToggle}
-        onTogglePurchased={onToggle}
+        onTogglePurchased={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Eggs")).toBeInTheDocument();
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+  });
+
+  it("shows purchased state", () => {
+    render(
+      <ShoppingListItems
+        items={items}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        onTogglePurchased={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Milk")).toHaveClass("line-through");
+  });
+
+  it("calls onTogglePurchased when item is clicked", () => {
+    const onTogglePurchased = vi.fn();
+    render(
+      <ShoppingListItems
+        items={items}
+        onDelete={vi.fn()}
+        onEdit={vi.fn()}
+        onTogglePurchased={onTogglePurchased}
       />
     );
     // The first button in the row is the toggle button
     const btn = screen.getAllByRole("button")[0];
     fireEvent.click(btn);
-    expect(onToggle).toHaveBeenCalledWith("1", false);
+    expect(onTogglePurchased).toHaveBeenCalledWith("1", false);
   });
 });

--- a/src/components/shopping/ShoppingListItems.tsx
+++ b/src/components/shopping/ShoppingListItems.tsx
@@ -31,9 +31,7 @@ const SHOPPING_LIST_SKELETON_KEYS = [
   "shopping-list-skeleton-8",
 ];
 
-const VirtualizedShoppingRow: React.FC<
-  RowComponentProps<VirtualizedShoppingRowData>
-> = ({
+const VirtualizedShoppingRow = ({
   ariaAttributes,
   index,
   style,
@@ -41,7 +39,7 @@ const VirtualizedShoppingRow: React.FC<
   onEdit,
   onDelete,
   onTogglePurchased,
-}) => {
+}: RowComponentProps<VirtualizedShoppingRowData>) => {
   const item = items[index];
 
   if (!item) {

--- a/src/components/ui/Input.test.tsx
+++ b/src/components/ui/Input.test.tsx
@@ -14,7 +14,7 @@ describe("Input", () => {
         value="abc"
       />
     );
-    const input = screen.getByPlaceholderText("Type here");
+    const input = screen.getByPlaceholderText<HTMLInputElement>("Type here");
     expect(input).toBeInTheDocument();
     expect(input.value).toBe("abc");
   });

--- a/src/pages/Pantry.tsx
+++ b/src/pages/Pantry.tsx
@@ -89,7 +89,10 @@ const ingredientSchema = z.object({
     z.number().min(0, "Threshold must be positive").optional()
   ),
 });
-type IngredientFormData = z.infer<typeof ingredientSchema>;
+// The schema uses z.preprocess, so its input type (raw form values) differs
+// from its output type (parsed values handed to onSubmit).
+type IngredientFormInput = z.input<typeof ingredientSchema>;
+type IngredientFormData = z.output<typeof ingredientSchema>;
 
 const SORT_OPTIONS = [
   { value: "name", label: "Name" },
@@ -169,7 +172,7 @@ export function Pantry() {
     null
   );
   const { register, handleSubmit, reset, setValue, control, getValues } =
-    useForm<IngredientFormData>({
+    useForm<IngredientFormInput, unknown, IngredientFormData>({
       resolver: zodResolver(ingredientSchema),
       defaultValues: {
         name: "",

--- a/src/pages/Shopping.tsx
+++ b/src/pages/Shopping.tsx
@@ -362,7 +362,7 @@ export function Shopping() {
     // Zod validation
     const result = ItemFormSchema.safeParse(itemFormData);
     if (!result.success) {
-      toast.error(result.error.errors[0].message);
+      toast.error(result.error.issues[0].message);
       return;
     }
 


### PR DESCRIPTION
## Summary
Resolves the **26 TypeScript errors** that the new `typecheck` gate (`tsc -b --noEmit`) surfaces. These pre-existed on `main` — they only became visible once the typecheck was wired into the build. `bun run typecheck` now reports **0 errors** and the build is green.

## Source fixes (real type bugs)
- **`fix(zod)`** — Zod v4 renamed `ZodError.errors` → `.issues`; updated `Shopping.tsx`.
- **`fix(ai-chat)`** — react-markdown v10 dropped the `className` prop; wrapped `<ReactMarkdown>` in a styled `<div>`.
- **`fix(forms)`** — corrected react-hook-form resolver types: `AuthForm` unifies sign-in/sign-up schemas behind one `Resolver<SignUpFormData>`; `Pantry`'s `z.preprocess` schema gets distinct `useForm` input/output type params.
- **`fix(react-window)`** — React 19's `FC` returns `ReactNode`, not assignable to react-window's `cellComponent`/`rowComponent` signature; typed the props directly instead.

## Test fixes
- Completed `Recipe`, `ShoppingListItem`, and Supabase `User` mocks (`satisfies` to keep literal types; filled required fields).
- Replaced the non-existent `onToggle` prop with the real `onTogglePurchased` in shopping list tests.
- Added required `onCancel` to `LeftoverForm` tests; typed `Wrapper` children.
- `global` → `globalThis`; read `.value` through `HTMLInputElement`.

## Verification
- `bun run typecheck` → 0 errors
- `bun run check` → clean
- `bun run test` → 91 passing (unchanged)
- `bun run build` → green

No tests were weakened to satisfy types; bogus props were replaced with the real component API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)